### PR TITLE
removed extra init file on root dir

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,0 @@
-#!/usr/bin/env python


### PR DESCRIPTION
There was an extra __init__.py file in the root directory that got added in previous merges. With this, if the parent folder of the repo directory is in the pythonpath, python would think the repo itself is a package with the name mphys, and imports from mphys did not work. without this extra init, if the users install the package with `pip install -e .`, imports work.