### PR TITLE
updates to the adflow wrapper.

### DIFF
--- a/examples/mach_tutorials/aero_opt/mphys_aero.py
+++ b/examples/mach_tutorials/aero_opt/mphys_aero.py
@@ -31,8 +31,8 @@ class Top(om.Group):
             'outputDirectory':'.',
             'monitorvariables':['resrho','resturb','cl','cd'],
             'writeTecplotSurfaceSolution':False,
-            'writevolumesolution':False,
-            'writesurfacesolution':False,
+            # 'writevolumesolution':False,
+            # 'writesurfacesolution':False,
 
             # Physics Parameters
             'equationType':'RANS',

--- a/examples/mach_tutorials/aero_opt/mphys_aero_2pt.py
+++ b/examples/mach_tutorials/aero_opt/mphys_aero_2pt.py
@@ -31,8 +31,8 @@ class Top(om.Group):
             'outputDirectory':'.',
             'monitorvariables':['resrho','resturb','cl','cd'],
             'writeTecplotSurfaceSolution':False,
-            'writevolumesolution':False,
-            'writesurfacesolution':False,
+            # 'writevolumesolution':False,
+            # 'writesurfacesolution':False,
 
             # Physics Parameters
             'equationType':'RANS',

--- a/examples/mach_tutorials/aerostruct/mphys_as.py
+++ b/examples/mach_tutorials/aerostruct/mphys_as.py
@@ -37,8 +37,8 @@ class Top(om.Group):
             'outputDirectory':'.',
             'monitorvariables':['resrho','resturb','cl','cd'],
             'writeTecplotSurfaceSolution':False,
-            'writevolumesolution':False,
-            'writesurfacesolution':False,
+            # 'writevolumesolution':False,
+            # 'writesurfacesolution':False,
 
             # Physics Parameters
             'equationType':'RANS',

--- a/examples/mach_tutorials/aerostruct/mphys_as_2scenario.py
+++ b/examples/mach_tutorials/aerostruct/mphys_as_2scenario.py
@@ -37,8 +37,8 @@ class Top(om.Group):
             'outputDirectory':'.',
             'monitorvariables':['resrho','cl','cd'],
             'writeTecplotSurfaceSolution':False,
-            'writevolumesolution':False,
-            'writesurfacesolution':False,
+            # 'writevolumesolution':False,
+            # 'writesurfacesolution':False,
 
             # Physics Parameters
             'equationType':'RANS',


### PR DESCRIPTION
This PR includes a number of modifications to the mphys_adflow wrapper:

1. The solver behavior is modified, such that if the solver fails after a restart, it will reset the flow and try again.
2. The functionals component that is added to the scenario level outputs the surface and solution files once after the MDA converges. This way, we do not need to output a file at each NLBGS iteration, and just do it once. The output file names are named after the aero problem name, and number is incremented after each MDA (similar to default adflow behavior).
3. Added the "hooks" required for aeropropulsive problems. The functionals group is modified so that it can be repurposed as an in-mda-loop propulsion outputs, and as an out-of-mda-loop functionals group, all with the same code. Also added an optional balance comp that can be added externally, but this will be modified again soon. 
4. Added the option to have the volume warping done in the mesh element, rather than the solver element. This is useful for aeropropulsive cases, where we want to iterate the MDA, but we will not update the mesh at each iteration. This way, the mesh is updated once by the mesh group, and each scenario's solver group iterates with a fixed mesh. Default behavior is also maintained for aerostructural cases, where we do update the volume mesh for the MDA iterations.

The example scripts using adflow still run after these changes. Also, my aeropropulsive case also runs with these changes.