### PR TITLE
Fix MELD derivatives for multiple instances of meld components.

### DIFF
--- a/mphys/mphys_meld.py
+++ b/mphys/mphys_meld.py
@@ -96,6 +96,17 @@ class MeldDispXfer(om.ExplicitComponent):
             D = u_a - g(u_s,x_a0,x_s0)
         So explicit partials below for u_a are negative partials of D
         """
+        if self.check_partials:
+            x_s0 = np.array(inputs['x_s0'],dtype=TransferScheme.dtype)
+            x_a0 = np.array(inputs['x_a0'],dtype=TransferScheme.dtype)
+            self.meld.setStructNodes(x_s0)
+            self.meld.setAeroNodes(x_a0)
+        u_s  = np.zeros(self.struct_nnodes*3,dtype=TransferScheme.dtype)
+        for i in range(3):
+            u_s[i::3] = inputs['u_s'][i::self.struct_ndof]
+        u_a = np.zeros(self.aero_nnodes*3,dtype=TransferScheme.dtype)
+        self.meld.transferDisps(u_s,u_a)
+
         if mode == 'fwd':
             if 'u_a' in d_outputs:
                 if 'u_s' in d_inputs:
@@ -209,24 +220,19 @@ class MeldLoadXfer(om.ExplicitComponent):
         #self.declare_partials('f_s',['x_s0','x_a0','u_s','f_a'])
 
     def compute(self, inputs, outputs):
-        u_s  = np.zeros(self.struct_nnodes*3)
-        for i in range(3):
-            u_s[i::3] = inputs['u_s'][i::self.struct_ndof]
-
-        f_a =  np.array(inputs['f_a'],dtype=TransferScheme.dtype)
-        f_s = np.zeros(self.struct_nnodes*3,dtype=TransferScheme.dtype)
-
         if self.check_partials:
             x_s0 = np.array(inputs['x_s0'],dtype=TransferScheme.dtype)
             x_a0 = np.array(inputs['x_a0'],dtype=TransferScheme.dtype)
             self.meld.setStructNodes(x_s0)
             self.meld.setAeroNodes(x_a0)
-            #TODO meld needs a set state rather requiring transferDisps to update the internal state
-            u_s  = np.zeros(self.struct_nnodes*3,dtype=TransferScheme.dtype)
-            for i in range(3):
-                u_s[i::3] = inputs['u_s'][i::self.struct_ndof]
-            u_a = np.zeros(inputs['f_a'].size,dtype=TransferScheme.dtype)
-            self.meld.transferDisps(u_s,u_a)
+        f_a =  np.array(inputs['f_a'],dtype=TransferScheme.dtype)
+        f_s = np.zeros(self.struct_nnodes*3,dtype=TransferScheme.dtype)
+
+        u_s  = np.zeros(self.struct_nnodes*3,dtype=TransferScheme.dtype)
+        for i in range(3):
+            u_s[i::3] = inputs['u_s'][i::self.struct_ndof]
+        u_a = np.zeros(inputs['f_a'].size,dtype=TransferScheme.dtype)
+        self.meld.transferDisps(u_s,u_a)
 
         self.meld.transferLoads(f_a,f_s)
 
@@ -242,6 +248,21 @@ class MeldLoadXfer(om.ExplicitComponent):
             L = f_s - g(f_a,u_s,x_a0,x_s0)
         So explicit partials below for f_s are negative partials of L
         """
+        if self.check_partials:
+            x_s0 = np.array(inputs['x_s0'],dtype=TransferScheme.dtype)
+            x_a0 = np.array(inputs['x_a0'],dtype=TransferScheme.dtype)
+            self.meld.setStructNodes(x_s0)
+            self.meld.setAeroNodes(x_a0)
+        f_a =  np.array(inputs['f_a'],dtype=TransferScheme.dtype)
+        f_s = np.zeros(self.struct_nnodes*3,dtype=TransferScheme.dtype)
+
+        u_s  = np.zeros(self.struct_nnodes*3,dtype=TransferScheme.dtype)
+        for i in range(3):
+            u_s[i::3] = inputs['u_s'][i::self.struct_ndof]
+        u_a = np.zeros(inputs['f_a'].size,dtype=TransferScheme.dtype)
+        self.meld.transferDisps(u_s,u_a)
+        self.meld.transferLoads(f_a,f_s)
+
         if mode == 'fwd':
             if 'f_s' in d_outputs:
                 if 'u_s' in d_inputs:

--- a/tests/meld_check_partials.py
+++ b/tests/meld_check_partials.py
@@ -10,7 +10,7 @@ from funtofem import TransferScheme
 
 class FakeStructMesh(om.ExplicitComponent):
     def initialize(self):
-        self.nodes = np.random.rand(15)
+        self.nodes = np.random.rand(12)
 
     def setup(self):
         self.add_output('x_s',shape=self.nodes.size)
@@ -20,7 +20,8 @@ class FakeStructMesh(om.ExplicitComponent):
 
 class FakeStructDisps(om.ExplicitComponent):
     def initialize(self):
-        self.nodes = np.random.rand(15)
+        self.nodes = np.random.rand(12)
+        self.nodes = np.arange(12)
 
     def setup(self):
         self.add_output('u_s',shape=self.nodes.size)
@@ -28,9 +29,19 @@ class FakeStructDisps(om.ExplicitComponent):
     def compute(self,inputs,outputs):
         outputs['u_s'] = self.nodes
 
+class FakeAeroLoads(om.ExplicitComponent):
+    def initialize(self):
+        self.nodes = np.random.rand(12)
+
+    def setup(self):
+        self.add_output('f_a',shape=self.nodes.size)
+
+    def compute(self,inputs,outputs):
+        outputs['f_a'] = self.nodes
+
 class FakeAeroMesh(om.ExplicitComponent):
     def initialize(self):
-        self.nodes = np.random.rand(15)
+        self.nodes = np.random.rand(12)
 
     def setup(self):
         self.add_output('x_a',shape=self.nodes.size)
@@ -45,22 +56,33 @@ beta = 0.5
 meld = TransferScheme.pyMELD(comm, comm,0, comm,0, isym,n,beta)
 
 struct_ndof = 3
-struct_nnodes = 5
-aero_nnodes = 5
+struct_nnodes = 4
+aero_nnodes = 4
 
 prob = om.Problem()
 prob.model.add_subsystem('aero_mesh',FakeAeroMesh())
 prob.model.add_subsystem('struct_mesh',FakeStructMesh())
 prob.model.add_subsystem('struct_disps',FakeStructDisps())
-disp = prob.model.add_subsystem('disp_xfer',MeldDispXfer(xfer_object=meld,struct_ndof=struct_ndof,struct_nnodes=struct_nnodes,aero_nnodes=aero_nnodes))
-load = prob.model.add_subsystem('load_xfer',MeldLoadXfer(xfer_object=meld,struct_ndof=struct_ndof,struct_nnodes=struct_nnodes,aero_nnodes=aero_nnodes))
+prob.model.add_subsystem('aero_loads',FakeAeroLoads())
+disp = prob.model.add_subsystem('disp_xfer',MeldDispXfer(xfer_object=meld,struct_ndof=struct_ndof,struct_nnodes=struct_nnodes,aero_nnodes=aero_nnodes,check_partials=True))
+load = prob.model.add_subsystem('load_xfer',MeldLoadXfer(xfer_object=meld,struct_ndof=struct_ndof,struct_nnodes=struct_nnodes,aero_nnodes=aero_nnodes,check_partials=True))
 
-disp.check_partials = True
-load.check_partials = True
+prob.model.add_subsystem('aero_mesh2',FakeAeroMesh())
+prob.model.add_subsystem('struct_mesh2',FakeStructMesh())
+prob.model.add_subsystem('struct_disps2',FakeStructDisps())
+prob.model.add_subsystem('aero_loads2',FakeAeroLoads())
+disp = prob.model.add_subsystem('disp_xfer2',MeldDispXfer(xfer_object=meld,struct_ndof=struct_ndof,struct_nnodes=struct_nnodes,aero_nnodes=aero_nnodes,check_partials=True))
+load = prob.model.add_subsystem('load_xfer2',MeldLoadXfer(xfer_object=meld,struct_ndof=struct_ndof,struct_nnodes=struct_nnodes,aero_nnodes=aero_nnodes,check_partials=True))
 
 prob.model.connect('aero_mesh.x_a',['disp_xfer.x_a0','load_xfer.x_a0'])
 prob.model.connect('struct_mesh.x_s',['disp_xfer.x_s0','load_xfer.x_s0'])
 prob.model.connect('struct_disps.u_s',['disp_xfer.u_s','load_xfer.u_s'])
+prob.model.connect('aero_loads.f_a',['load_xfer.f_a'])
+
+prob.model.connect('aero_mesh2.x_a',['disp_xfer2.x_a0','load_xfer2.x_a0'])
+prob.model.connect('struct_mesh2.x_s',['disp_xfer2.x_s0','load_xfer2.x_s0'])
+prob.model.connect('struct_disps2.u_s',['disp_xfer2.u_s','load_xfer2.u_s'])
+prob.model.connect('aero_loads2.f_a',['load_xfer2.f_a'])
 
 
 prob.setup(force_alloc_complex=True)


### PR DESCRIPTION
Since MELD is nonlinear, we need to set current states back into MELD at start of compute jacvec
products by calling transferDisps again.