### PR TITLE
Added solution failure handling to the ADflow wrapper

### DIFF
--- a/mphys/mphys_adflow.py
+++ b/mphys/mphys_adflow.py
@@ -375,9 +375,9 @@ class ADflowSolver(ImplicitComponent):
                     solver.writeSolution(baseName='analysis_fail' ,number=self.solution_counter)
                     self.solution_counter += 1
 
-                    solver.resetFlow(ap)
-                    self.cleanRestart = True
                     if self.analysis_error_on_failure:
+                        solver.resetFlow(ap)
+                        self.cleanRestart = True
                         raise AnalysisError('ADFLOW Solver Fatal Fail')
 
                 # the previous iteration restarted from another solution, so we can try again
@@ -407,11 +407,11 @@ class ADflowSolver(ImplicitComponent):
                         solver.writeSolution(baseName='analysis_fail' ,number=self.solution_counter)
                         self.solution_counter += 1
 
-                        # re-set the flow for the next iteration:
-                        solver.resetFlow(ap)
-                        # set the reset flow flag
-                        self.cleanRestart = True
                         if self.analysis_error_on_failure:
+                            # re-set the flow for the next iteration:
+                            solver.resetFlow(ap)
+                            # set the reset flow flag
+                            self.cleanRestart = True
                             raise AnalysisError('ADFLOW Solver Fatal Fail')
 
                     # see comment for the same flag below


### PR DESCRIPTION
With these changes, the ADflow wrapper can handle solution failures: If the current solution that failed was restarted from a previous state, it will re-set the flow and try again, or if the current solution was a clean start already, ADflow will raise `AnalysisError` and this will be passed back as a fail flag to the optimizer drivers.

Furthermore, it will write a solution file for failed simulations for debugging. I also added an option to disable the raising of `AnalysisError`, if the users want to overwrite the default behavior. 