### PR TITLE
Added DAFoam

### DIFF
--- a/mphys/mphys_dafoam.py
+++ b/mphys/mphys_dafoam.py
@@ -140,7 +140,7 @@ class DAFoamSolver(ImplicitComponent):
         # setup input and output for the solver
         local_state_size = self.DASolver.getNLocalAdjointStates()
         self.add_input("dafoam_vol_coords", distributed=True, shape_by_conn=True, tags=["mphys_coupling"])
-        self.add_input("aoa", units="rad", shape_by_conn=True, distributed=False, tags=["mphys_coupling"])
+        self.add_input("aoa", units="deg", shape_by_conn=True, distributed=False, tags=["mphys_coupling"])
         self.add_output("dafoam_states", distributed=True, shape=local_state_size, tags=["mphys_coupling"])
 
     # calculate the residual
@@ -374,11 +374,10 @@ class DAFoamFunctions(ExplicitComponent):
         # a list that contains all function names, e.g., CD, CL
         self.funcs = None
 
-        self.nProcs = self.comm.size
-
     def setup(self):
 
         self.DASolver = self.options["solver"]
+        self.nProcs = self.comm.size
 
         # Initialze AOA option
         self.aoa_func = None

--- a/tests/integration_tests/test_dafoam_derivs.py
+++ b/tests/integration_tests/test_dafoam_derivs.py
@@ -152,7 +152,7 @@ class Top(Multipoint):
                 geo.rot_z["wingAxis"].coef[i] = -val[i - 1]
 
         def alpha(val, DASolver):
-            aoa = val[0]
+            aoa = val[0] * np.pi / 180.0
             U = [float(self.U0 * np.cos(aoa)), float(self.U0 * np.sin(aoa)), 0]
             DASolver.setOption("primalBC", {"U0": {"variable": "U", "patches": ["inout"], "value": U}})
             DASolver.updateDAOption()
@@ -173,7 +173,7 @@ class Top(Multipoint):
         # add dvs to ivc and connect
         self.dvs.add_output("twist", val=np.array([0] * (nRefAxPts - 1)))
         self.dvs.add_output("shape", val=np.array([0] * nShapes))
-        self.dvs.add_output("aoa", val=np.array([0]))
+        self.dvs.add_output("aoa", units="deg", val=np.array([0]))
         self.connect("twist", "geometry.twist")
         self.connect("shape", "geometry.shape")
         self.connect("aoa", "cruise.aoa")

--- a/tests/regression_tests/test_dafoam.py
+++ b/tests/regression_tests/test_dafoam.py
@@ -155,7 +155,7 @@ class Top(Multipoint):
                 geo.rot_z["wingAxis"].coef[i] = -val[i - 1]
 
         def alpha(val, DASolver):
-            aoa = val[0]
+            aoa = val[0] * np.pi / 180.0
             U = [float(self.U0 * np.cos(aoa)), float(self.U0 * np.sin(aoa)), 0]
             DASolver.setOption("primalBC", {"U0": {"variable": "U", "patches": ["inout"], "value": U}})
             DASolver.updateDAOption()
@@ -176,7 +176,7 @@ class Top(Multipoint):
         # add dvs to ivc and connect
         self.dvs.add_output("twist", val=np.array([0] * (nRefAxPts - 1)))
         self.dvs.add_output("shape", val=np.array([0] * nShapes))
-        self.dvs.add_output("aoa", val=np.array([0]))
+        self.dvs.add_output("aoa", units="deg", val=np.array([0]))
         self.connect("twist", "geometry.twist")
         self.connect("shape", "geometry.shape")
         self.connect("aoa", "cruise.aoa")


### PR DESCRIPTION
Added mphys_dafoam.py along with test scripts. Currently, it can do aerodynamic-only optimization with OpenFOAM and DAFoam. Adjoint accuracy matched FD with about 4 digits in parallel. Need feedback on regression tests.