### PR TITLE
Adding minimal install_requires to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,9 @@ setup(
     author="",
     author_email="",
     zip_safe=False,
-    packages = find_packages()
+    packages = find_packages(),
+    install_requires=[
+          'numpy',
+          'openmdao'
+    ],
 )


### PR DESCRIPTION
- Adding minimal install dependencies to setup.py
- I think mphys only needs numpy and openmdao at minimum