### PR TITLE
Minor update for OpenMDAO version requirement.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,6 @@ setup(
     packages = find_packages(),
     install_requires=[
           'numpy',
-          'openmdao>=3.15,<3.17'
+          'openmdao>=3.15,!=3.17'
     ],
 )


### PR DESCRIPTION
Removing upper bound version limit on OpenMDAO.
Allowing any version >= 3.15, but skipping 3.17 (due to parallel bug)