### PR TITLE
Fixing missing package for installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import os
 from setuptools import setup, find_packages
 
 __package_name__ = "mphys"


### PR DESCRIPTION
The current `setup.py` file is missing an import, causing the following error:

```
Obtaining file:///home/bpacini/MDOLabCodes/repos/mphys
    ERROR: Command errored out with exit status 1:
     command: /home/bpacini/MDOLabCodes/MDOLAB_VENV/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/home/bpacini/MDOLabCodes/repos/mphys/setup.py'"'"'; __file__='"'"'/home/bpacini/MDOLabCodes/repos/mphys/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info
         cwd: /home/bpacini/MDOLabCodes/repos/mphys/
    Complete output (5 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/home/bpacini/MDOLabCodes/repos/mphys/setup.py", line 6, in <module>
        mphys_root = os.path.abspath(os.path.dirname(__file__))
    NameError: name 'os' is not defined
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```

when trying to install MPHYS. Adding `import os` to the top (as required by the script) fixes this issue.