### PR TITLE
Adding integration test for TACS to CI

### DIFF
--- a/.github/workflows/unit_tests_and_docs.yml
+++ b/.github/workflows/unit_tests_and_docs.yml
@@ -81,7 +81,7 @@ jobs:
           chmod +x get-input-files.sh
           ./get-input-files.sh
           cd ../integration_tests
-          testflo test_tacs_derivs.py
+          testflo test_tacs_*
           echo "=============================================================";
           echo "Making docs";
           echo "=============================================================";

--- a/.github/workflows/unit_tests_and_docs.yml
+++ b/.github/workflows/unit_tests_and_docs.yml
@@ -62,10 +62,16 @@ jobs:
           cd ../mphys;
           pip install -e .
           echo "=============================================================";
+          echo "Install TACS (complex)";
+          echo "=============================================================";
+          conda install -c conda-forge -c smdogroup -c "smdogroup/label/complex" tacs;
+          echo "=============================================================";
           echo "List installed packages/versions";
           echo "=============================================================";
           conda list;
           cd tests/unit_tests
           testflo
+          cd ../integration_tests
+          testflo test_tacs_derivs.py
           cd ../../docs
           make html

--- a/.github/workflows/unit_tests_and_docs.yml
+++ b/.github/workflows/unit_tests_and_docs.yml
@@ -69,12 +69,21 @@ jobs:
           echo "List installed packages/versions";
           echo "=============================================================";
           conda list;
+          echo "=============================================================";
+          echo "Running unit tests";
+          echo "=============================================================";
           cd tests/unit_tests
           testflo
+          echo "=============================================================";
+          echo "Running integration tests";
+          echo "=============================================================";
           cd ../input_files
           chmod +x get-input-files.sh
           ./get-input-files.sh
           cd ../integration_tests
           testflo test_tacs_derivs.py
+          echo "=============================================================";
+          echo "Making docs";
+          echo "=============================================================";
           cd ../../docs
           make html

--- a/.github/workflows/unit_tests_and_docs.yml
+++ b/.github/workflows/unit_tests_and_docs.yml
@@ -64,7 +64,7 @@ jobs:
           echo "=============================================================";
           echo "Install TACS (complex)";
           echo "=============================================================";
-          conda install -c conda-forge -c smdogroup -c "smdogroup/label/complex" tacs;
+          conda install -c conda-forge -c "smdogroup/label/complex" -c smdogroup tacs;
           echo "=============================================================";
           echo "List installed packages/versions";
           echo "=============================================================";

--- a/.github/workflows/unit_tests_and_docs.yml
+++ b/.github/workflows/unit_tests_and_docs.yml
@@ -71,6 +71,9 @@ jobs:
           conda list;
           cd tests/unit_tests
           testflo
+          cd ../input_files
+          chmod +x get-input-files.sh
+          ./get-input-files.sh
           cd ../integration_tests
           testflo test_tacs_derivs.py
           cd ../../docs


### PR DESCRIPTION
- I noticed that we don't run any of the integration tests on the CI and figured it would probably be good to at least run one of them
- Using tacs conda installer, I added an additional testflo step where the tacs integration sensitivity test is run after the unit tests
- Hopefully adding tests like this to the CI can also catch issues like OpenMDAO/OpenMDAO#2498 on the mphys side