### PR TITLE
Bump to version 1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 __package_name__ = "mphys"
-__package_version__ = "1.0.0"
+__package_version__ = "1.1.0"
 
 mphys_root = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(mphys_root, 'README.md'), encoding='utf-8') as f:


### PR DESCRIPTION
Bump to version 1.1 to put a version constraint on OpenMDAO >=3.25 due to change in parallel derivative convention