### PR TITLE
Uncommenting TACS tests in CI

### DIFF
--- a/.github/workflows/unit_tests_and_docs.yml
+++ b/.github/workflows/unit_tests_and_docs.yml
@@ -61,10 +61,10 @@ jobs:
           pip install .[all];
           cd ../mphys;
           pip install -e .
-          # echo "=============================================================";
-          # echo "Install TACS (complex)";
-          # echo "=============================================================";
-          # conda install -c conda-forge -c "smdogroup/label/complex" -c smdogroup tacs;
+          echo "=============================================================";
+          echo "Install TACS (complex)";
+          echo "=============================================================";
+          conda install -c conda-forge -c "smdogroup/label/complex" -c smdogroup tacs;
           echo "=============================================================";
           echo "List installed packages/versions";
           echo "=============================================================";
@@ -74,14 +74,14 @@ jobs:
           echo "=============================================================";
           cd tests/unit_tests
           testflo
-          # echo "=============================================================";
-          # echo "Running integration tests";
-          # echo "=============================================================";
-          # cd ../input_files
-          # chmod +x get-input-files.sh
-          # ./get-input-files.sh
-          # cd ../integration_tests
-          # testflo test_tacs_*
+          echo "=============================================================";
+          echo "Running integration tests";
+          echo "=============================================================";
+          cd ../input_files
+          chmod +x get-input-files.sh
+          ./get-input-files.sh
+          cd ../integration_tests
+          testflo test_tacs_*
           echo "=============================================================";
           echo "Making docs";
           echo "=============================================================";


### PR DESCRIPTION
- TACS has been updated to work w/ OpenMCSO 3.25
- Turning TACS integration tests back on in CI