### PR TITLE
Add option to switch the coupling group type in aerostructural

### DIFF
--- a/mphys/scenario_aerostructural.py
+++ b/mphys/scenario_aerostructural.py
@@ -40,8 +40,8 @@ class ScenarioAeroStructural(Scenario):
         )
         self.options.declare(
             "coupling_group_type",
-            default="aerostructural",
-            desc='Limited flexibility for coupling group type to accomodate flutter about jig shape or DLM where coupling group can be skipped: ["aerostructural", "aerodynamics_only", None]',
+            default="full_coupling",
+            desc='Limited flexibility for coupling group type to accomodate flutter about jig shape or DLM where coupling group can be skipped: ["full_coupling", "aerodynamics_only", None]',
         )
 
     def _mphys_scenario_setup(self):
@@ -68,7 +68,7 @@ class ScenarioAeroStructural(Scenario):
             "ldxfer", ldxfer_builder, self.name
         )
 
-        if self.options["coupling_group_type"] == "aerostructural":
+        if self.options["coupling_group_type"] == "full_coupling":
             coupling_group = CouplingAeroStructural(
                 aero_builder=aero_builder,
                 struct_builder=struct_builder,

--- a/mphys/scenario_aerostructural.py
+++ b/mphys/scenario_aerostructural.py
@@ -4,7 +4,6 @@ from .coupling_aerostructural import CouplingAeroStructural
 
 
 class ScenarioAeroStructural(Scenario):
-
     def initialize(self):
         """
         A class to perform a single discipline aerodynamic case.
@@ -13,60 +12,114 @@ class ScenarioAeroStructural(Scenario):
         """
         super().initialize()
 
-        self.options.declare('aero_builder', recordable=False,
-                              desc='The MPhys builder for the aerodynamic solver')
-        self.options.declare('struct_builder', recordable=False,
-                              desc='The MPhys builder for the structural solver')
-        self.options.declare('ldxfer_builder', recordable=False,
-                              desc='The MPhys builder for the load and displacement transfer')
-        self.options.declare('in_MultipointParallel', default=False,
-                             desc='Set to `True` if adding this scenario inside a MultipointParallel Group.')
-        self.options.declare('geometry_builder', default=None, recordable=False,
-                             desc='The optional MPhys builder for the geometry')
+        self.options.declare(
+            "aero_builder",
+            recordable=False,
+            desc="The MPhys builder for the aerodynamic solver",
+        )
+        self.options.declare(
+            "struct_builder",
+            recordable=False,
+            desc="The MPhys builder for the structural solver",
+        )
+        self.options.declare(
+            "ldxfer_builder",
+            recordable=False,
+            desc="The MPhys builder for the load and displacement transfer",
+        )
+        self.options.declare(
+            "in_MultipointParallel",
+            default=False,
+            desc="Set to `True` if adding this scenario inside a MultipointParallel Group.",
+        )
+        self.options.declare(
+            "geometry_builder",
+            default=None,
+            recordable=False,
+            desc="The optional MPhys builder for the geometry",
+        )
+        self.options.declare(
+            "coupling_group_type",
+            default="aerostructural",
+            desc='Limited flexibility for coupling group type to accomodate flutter about jig shape or DLM where coupling group can be skipped: ["aerostructural", "aerodynamics_only", None]',
+        )
 
     def _mphys_scenario_setup(self):
-        aero_builder = self.options['aero_builder']
-        struct_builder = self.options['struct_builder']
-        ldxfer_builder = self.options['ldxfer_builder']
-        geometry_builder = self.options['geometry_builder']
+        aero_builder = self.options["aero_builder"]
+        struct_builder = self.options["struct_builder"]
+        ldxfer_builder = self.options["ldxfer_builder"]
+        geometry_builder = self.options["geometry_builder"]
 
-        if self.options['in_MultipointParallel']:
-            self._mphys_initialize_builders(aero_builder, struct_builder,
-                                            ldxfer_builder, geometry_builder)
-            self._mphys_add_mesh_and_geometry_subsystems(aero_builder, struct_builder,
-                                                         geometry_builder)
+        if self.options["in_MultipointParallel"]:
+            self._mphys_initialize_builders(
+                aero_builder, struct_builder, ldxfer_builder, geometry_builder
+            )
+            self._mphys_add_mesh_and_geometry_subsystems(
+                aero_builder, struct_builder, geometry_builder
+            )
 
-        self._mphys_add_pre_coupling_subsystem_from_builder('aero', aero_builder, self.name)
-        self._mphys_add_pre_coupling_subsystem_from_builder('struct', struct_builder, self.name)
-        self._mphys_add_pre_coupling_subsystem_from_builder('ldxfer', ldxfer_builder, self.name)
+        self._mphys_add_pre_coupling_subsystem_from_builder(
+            "aero", aero_builder, self.name
+        )
+        self._mphys_add_pre_coupling_subsystem_from_builder(
+            "struct", struct_builder, self.name
+        )
+        self._mphys_add_pre_coupling_subsystem_from_builder(
+            "ldxfer", ldxfer_builder, self.name
+        )
 
-        coupling_group = CouplingAeroStructural(aero_builder=aero_builder,
-                                                struct_builder=struct_builder,
-                                                ldxfer_builder=ldxfer_builder,
-                                                scenario_name=self.name)
-        self.mphys_add_subsystem('coupling', coupling_group)
+        if self.options["coupling_group_type"] == "aerostructural":
+            coupling_group = CouplingAeroStructural(
+                aero_builder=aero_builder,
+                struct_builder=struct_builder,
+                ldxfer_builder=ldxfer_builder,
+                scenario_name=self.name,
+            )
+            self.mphys_add_subsystem("coupling", coupling_group)
 
-        self._mphys_add_post_coupling_subsystem_from_builder('ldxfer', ldxfer_builder, self.name)
-        self._mphys_add_post_coupling_subsystem_from_builder('aero', aero_builder, self.name)
-        self._mphys_add_post_coupling_subsystem_from_builder('struct', struct_builder, self.name)
+        elif self.options["coupling_group_type"] == "aerodynamics_only":
+            aero = aero_builder.get_coupling_group_subsystem(self.name)
+            self.mphys_add_subsystem("aero", aero)
 
-    def _mphys_initialize_builders(self, aero_builder, struct_builder,
-                                   ldxfer_builder, geometry_builder):
+        self._mphys_add_post_coupling_subsystem_from_builder(
+            "ldxfer", ldxfer_builder, self.name
+        )
+        self._mphys_add_post_coupling_subsystem_from_builder(
+            "aero", aero_builder, self.name
+        )
+        self._mphys_add_post_coupling_subsystem_from_builder(
+            "struct", struct_builder, self.name
+        )
+
+    def _mphys_initialize_builders(
+        self, aero_builder, struct_builder, ldxfer_builder, geometry_builder
+    ):
         aero_builder.initialize(self.comm)
         struct_builder.initialize(self.comm)
         ldxfer_builder.initialize(self.comm)
         if geometry_builder is not None:
             geometry_builder.initialize(self.comm)
 
-    def _mphys_add_mesh_and_geometry_subsystems(self, aero_builder, struct_builder,
-                                                geometry_builder):
+    def _mphys_add_mesh_and_geometry_subsystems(
+        self, aero_builder, struct_builder, geometry_builder
+    ):
 
         if geometry_builder is None:
-            self.mphys_add_subsystem('aero_mesh', aero_builder.get_mesh_coordinate_subsystem(self.name))
-            self.mphys_add_subsystem('struct_mesh', struct_builder.get_mesh_coordinate_subsystem(self.name))
+            self.mphys_add_subsystem(
+                "aero_mesh", aero_builder.get_mesh_coordinate_subsystem(self.name)
+            )
+            self.mphys_add_subsystem(
+                "struct_mesh", struct_builder.get_mesh_coordinate_subsystem(self.name)
+            )
         else:
-            self.add_subsystem('aero_mesh', aero_builder.get_mesh_coordinate_subsystem(self.name))
-            self.add_subsystem('struct_mesh', struct_builder.get_mesh_coordinate_subsystem(self.name))
-            self.mphys_add_subsystem('geometry', geometry_builder.get_mesh_coordinate_subsystem(self.name))
-            self.connect('aero_mesh.x_aero0', 'geometry.x_aero_in')
-            self.connect('struct_mesh.x_struct0', 'geometry.x_struct_in')
+            self.add_subsystem(
+                "aero_mesh", aero_builder.get_mesh_coordinate_subsystem(self.name)
+            )
+            self.add_subsystem(
+                "struct_mesh", struct_builder.get_mesh_coordinate_subsystem(self.name)
+            )
+            self.mphys_add_subsystem(
+                "geometry", geometry_builder.get_mesh_coordinate_subsystem(self.name)
+            )
+            self.connect("aero_mesh.x_aero0", "geometry.x_aero_in")
+            self.connect("struct_mesh.x_struct0", "geometry.x_struct_in")

--- a/tests/unit_tests/test_scenario_aerostructural.py
+++ b/tests/unit_tests/test_scenario_aerostructural.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import openmdao.api as om
 from mpi4py import MPI
 
@@ -160,6 +161,110 @@ class TestScenarioAeroStructuralParallelWithGeometry(unittest.TestCase):
         expected_order = ['disp_xfer', 'geo_disp', 'aero', 'load_xfer', 'struct']
         self.common.test_subsystem_order(self, self.prob.model.scenario.coupling, expected_order)
 
+class StructPostCouplingCompForNoCoupling(om.ExplicitComponent):
+    def setup(self):
+        self.add_input('prestate_struct', tags=['mphys_coupling'])
+        self.add_input('x_struct0', shape_by_conn=True, tags=['mphys_coordinates'])
+        self.add_output('func_struct', val=1.0, tags=['mphys_result'])
+
+    def compute(self, inputs, outputs):
+        outputs['func_struct'] = np.sum(inputs['prestate_struct'] + inputs['x_struct0'])
+
+class StructBuilderNoCoupling(StructBuilder):
+    def get_post_coupling_subsystem(self, scenario_name=None):
+        return StructPostCouplingCompForNoCoupling()
+
+class TestScenarioAeroStructuralAeroOnlyInCoupling(unittest.TestCase):
+    def setUp(self):
+        self.common = CommonMethods()
+        self.prob = om.Problem()
+
+        aero_builder = AeroBuilder()
+        struct_builder = StructBuilderNoCoupling()
+        ldxfer_builder = LDXferBuilder(aero_builder, struct_builder)
+
+        aero_builder.initialize(MPI.COMM_WORLD)
+        struct_builder.initialize(MPI.COMM_WORLD)
+        ldxfer_builder.initialize(MPI.COMM_WORLD)
+
+        self.prob.model.add_subsystem('aero_mesh', aero_builder.get_mesh_coordinate_subsystem())
+        self.prob.model.add_subsystem('struct_mesh', struct_builder.get_mesh_coordinate_subsystem())
+        self.prob.model.add_subsystem('scenario', ScenarioAeroStructural(aero_builder=aero_builder,
+                                                                  struct_builder=struct_builder,
+                                                                  ldxfer_builder=ldxfer_builder,
+                                                                  coupling_group_type='aerodynamics_only'))
+        self.prob.model.connect('aero_mesh.x_aero0', 'scenario.x_aero')
+        self.prob.model.connect('struct_mesh.x_struct0', 'scenario.x_struct0')
+        self.prob.setup()
+
+    def test_run_model(self):
+        self.common.test_run_model(self)
+
+    def test_scenario_components_were_added(self):
+        self.assertIsInstance(self.prob.model.scenario.aero_pre, AeroPreCouplingComp)
+        self.assertIsInstance(self.prob.model.scenario.struct_pre, StructPreCouplingComp)
+        self.assertIsInstance(self.prob.model.scenario.aero, AeroCouplingComp)
+        self.assertIsInstance(self.prob.model.scenario.aero_post, AeroPostCouplingComp)
+        self.assertIsInstance(self.prob.model.scenario.struct_post, StructPostCouplingCompForNoCoupling)
+
+    def test_scenario_subsystem_order(self):
+        expected_order = ['aero_pre', 'struct_pre', 'aero', 'aero_post', 'struct_post']
+        self.common.test_subsystem_order(self, self.prob.model.scenario, expected_order)
+
+    def test_no_autoivcs(self):
+        self.common.test_no_autoivcs(self)
+
+class AeroPostCouplingCompForNoCoupling(om.ExplicitComponent):
+    def setup(self):
+        self.add_input('prestate_aero', tags=['mphys_coupling'])
+        self.add_input('x_aero', shape_by_conn=True, tags=['mphys_coordinates'])
+        self.add_output('func_aero', val=1.0, tags=['mphys_result'])
+
+    def compute(self, inputs, outputs):
+        outputs['func_aero'] = np.sum(inputs['prestate_aero'] + inputs['x_aero'])
+
+class AeroBuilderNoCoupling(AeroBuilder):
+    def get_post_coupling_subsystem(self, scenario_name=None):
+        return AeroPostCouplingCompForNoCoupling()
+
+class TestScenarioAeroStructuralNoCoupling(unittest.TestCase):
+    def setUp(self):
+        self.common = CommonMethods()
+        self.prob = om.Problem()
+
+        aero_builder = AeroBuilderNoCoupling()
+        struct_builder = StructBuilderNoCoupling()
+        ldxfer_builder = LDXferBuilder(aero_builder, struct_builder)
+
+        aero_builder.initialize(MPI.COMM_WORLD)
+        struct_builder.initialize(MPI.COMM_WORLD)
+        ldxfer_builder.initialize(MPI.COMM_WORLD)
+
+        self.prob.model.add_subsystem('aero_mesh', aero_builder.get_mesh_coordinate_subsystem())
+        self.prob.model.add_subsystem('struct_mesh', struct_builder.get_mesh_coordinate_subsystem())
+        self.prob.model.add_subsystem('scenario', ScenarioAeroStructural(aero_builder=aero_builder,
+                                                                  struct_builder=struct_builder,
+                                                                  ldxfer_builder=ldxfer_builder,
+                                                                  coupling_group_type=None))
+        self.prob.model.connect('aero_mesh.x_aero0', 'scenario.x_aero')
+        self.prob.model.connect('struct_mesh.x_struct0', 'scenario.x_struct0')
+        self.prob.setup()
+
+    def test_run_model(self):
+        self.common.test_run_model(self)
+
+    def test_scenario_components_were_added(self):
+        self.assertIsInstance(self.prob.model.scenario.aero_pre, AeroPreCouplingComp)
+        self.assertIsInstance(self.prob.model.scenario.struct_pre, StructPreCouplingComp)
+        self.assertIsInstance(self.prob.model.scenario.aero_post, AeroPostCouplingCompForNoCoupling)
+        self.assertIsInstance(self.prob.model.scenario.struct_post, StructPostCouplingCompForNoCoupling)
+
+    def test_scenario_subsystem_order(self):
+        expected_order = ['aero_pre', 'struct_pre', 'aero_post', 'struct_post']
+        self.common.test_subsystem_order(self, self.prob.model.scenario, expected_order)
+
+    def test_no_autoivcs(self):
+        self.common.test_no_autoivcs(self)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This change adds the `"coupling_group_type"` option to the aerostructural scenario. This defaults to the standard aerostructural coupling group but allows two new types of aerostructural scenarios:

1. `"aerodynamics_only"`: coupling group for LFD-based flutter about the jig shape. Industry partners often compute GAFs about the jig shape so this mode would allow a steady jig shape aerodynamics analysis, followed by the post coupling groups for the flutter analysis.
2. `None`: DLM-based flutter analysis is linear aerodynamics and independent of the steady state if the structure is also linear, so this mode would allow the DLM-based flutter analysis to be in the post coupling group and be compatible with either linear or nonlinear structures.