### PR TITLE
no need to preinstall jupyter-book

### DIFF
--- a/.github/workflows/host_docs.yml
+++ b/.github/workflows/host_docs.yml
@@ -41,10 +41,6 @@ jobs:
           echo "Install PETSc";
           echo "=============================================================";
           conda install -c conda-forge mpi4py petsc4py -q -y;
-          echo "============================================================="
-          echo "Pre-install jupyter dependencies"
-          echo "============================================================="
-          python -m pip install git+https://github.com/executablebooks/jupyter-book
           echo "=============================================================";
           echo "Install OpenMDAO";
           echo "=============================================================";

--- a/.github/workflows/unit_tests_and_docs.yml
+++ b/.github/workflows/unit_tests_and_docs.yml
@@ -46,10 +46,6 @@ jobs:
           echo "Install PETSc";
           echo "=============================================================";
           conda install -c conda-forge mpi4py petsc4py -q -y;
-          echo "============================================================="
-          echo "Pre-install jupyter dependencies"
-          echo "============================================================="
-          python -m pip install git+https://github.com/executablebooks/jupyter-book
           echo "=============================================================";
           echo "Install OpenMDAO";
           echo "=============================================================";


### PR DESCRIPTION
The release of `jupyter-book` [v0.14.0](https://github.com/executablebooks/jupyter-book/releases/tag/v0.14.0) resolved the dependency issues we were having with OpenMDAO, so it is no longer necessary to pre-install it from the GitHub repository.