### PR TITLE
Fixing issue with OpenMDAO 3.26.1 breaking tests

### DIFF
--- a/tests/integration_tests/test_oas_tacs_meld_totals.py
+++ b/tests/integration_tests/test_oas_tacs_meld_totals.py
@@ -3,7 +3,7 @@ import unittest
 
 import numpy as np
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.assert_utils import assert_check_totals
 
 from mphys import Multipoint
 from mphys.scenario_aerostructural import ScenarioAeroStructural
@@ -164,18 +164,7 @@ class TestTACS(unittest.TestCase):
         data = self.prob.check_totals(of=['cruise.wing.CL', 'cruise.ks_vmfailure', 'cruise.mass'],
                                       wrt=['aoa', 'dv_struct'], method='fd', form='central',
                                       step=1e-5, step_calc='rel')
-        for var, err in data.items():
-            if err['magnitude'].fd == 0.0:
-                check_error = err['abs error']
-            else:
-                check_error = err['rel error']
-
-            if check_error.forward is not None:
-                err_val = check_error.forward
-            else:
-                err_val = check_error.reverse
-
-            assert_near_equal(err_val, 0.0, 1e-6)
+        assert_check_totals(data, atol=1e99, rtol=1e-6)
 
 
 if __name__ == '__main__':

--- a/tests/integration_tests/test_oas_tacs_meld_totals.py
+++ b/tests/integration_tests/test_oas_tacs_meld_totals.py
@@ -169,7 +169,13 @@ class TestTACS(unittest.TestCase):
                 check_error = err['abs error']
             else:
                 check_error = err['rel error']
-            assert_near_equal(check_error.forward, 0.0, 1e-6)
+
+            if check_error.forward is not None:
+                err_val = check_error.forward
+            else:
+                err_val = check_error.reverse
+
+            assert_near_equal(err_val, 0.0, 1e-6)
 
 
 if __name__ == '__main__':

--- a/tests/integration_tests/test_tacs_derivs.py
+++ b/tests/integration_tests/test_tacs_derivs.py
@@ -109,20 +109,32 @@ class TestTACS(unittest.TestCase):
                                       step=1e-50, step_calc='rel')
         for var, err in data.items():
             rel_err = err['rel error']
-            assert_near_equal(rel_err.forward, 0.0, 1e-7)
+            if rel_err.forward is not None:
+                err_val = rel_err.forward
+            else:
+                err_val = rel_err.reverse
+            assert_near_equal(err_val, 0.0, 1e-7)
 
         data = self.prob.check_totals(of=['analysis.ks_vmfailure'], wrt='f_struct',
                                       method='cs', step=1e-50, step_calc='rel')
         for var, err in data.items():
             rel_err = err['rel error']
-            assert_near_equal(rel_err.forward, 0.0, 5e-8)
+            if rel_err.forward is not None:
+                err_val = rel_err.forward
+            else:
+                err_val = rel_err.reverse
+            assert_near_equal(err_val, 0.0, 5e-8)
 
         data = self.prob.check_totals(of=['analysis.ks_vmfailure', 'analysis.mass'],
                                       wrt='dv_struct', method='cs',
                                       step=1e-50, step_calc='rel')
         for var, err in data.items():
             rel_err = err['rel error']
-            assert_near_equal(rel_err.forward, 0.0, 1e-8)
+            if rel_err.forward is not None:
+                err_val = rel_err.forward
+            else:
+                err_val = rel_err.reverse
+            assert_near_equal(err_val, 0.0, 1e-8)
 
 
 if __name__ == '__main__':

--- a/tests/integration_tests/test_tacs_derivs.py
+++ b/tests/integration_tests/test_tacs_derivs.py
@@ -14,7 +14,7 @@ import numpy as np
 
 # === Extension modules ===
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.assert_utils import assert_check_totals
 
 from mphys.multipoint import Multipoint
 from mphys.scenario_structural import ScenarioStructural
@@ -107,34 +107,16 @@ class TestTACS(unittest.TestCase):
         data = self.prob.check_totals(of=['analysis.ks_vmfailure', 'analysis.mass'],
                                       wrt='mesh.fea_mesh.x_struct0', method='cs',
                                       step=1e-50, step_calc='rel')
-        for var, err in data.items():
-            rel_err = err['rel error']
-            if rel_err.forward is not None:
-                err_val = rel_err.forward
-            else:
-                err_val = rel_err.reverse
-            assert_near_equal(err_val, 0.0, 1e-7)
+        assert_check_totals(data, atol=1e99, rtol=1e-7)
 
         data = self.prob.check_totals(of=['analysis.ks_vmfailure'], wrt='f_struct',
                                       method='cs', step=1e-50, step_calc='rel')
-        for var, err in data.items():
-            rel_err = err['rel error']
-            if rel_err.forward is not None:
-                err_val = rel_err.forward
-            else:
-                err_val = rel_err.reverse
-            assert_near_equal(err_val, 0.0, 5e-8)
+        assert_check_totals(data, atol=1e99, rtol=5e-8)
 
         data = self.prob.check_totals(of=['analysis.ks_vmfailure', 'analysis.mass'],
                                       wrt='dv_struct', method='cs',
                                       step=1e-50, step_calc='rel')
-        for var, err in data.items():
-            rel_err = err['rel error']
-            if rel_err.forward is not None:
-                err_val = rel_err.forward
-            else:
-                err_val = rel_err.reverse
-            assert_near_equal(err_val, 0.0, 1e-8)
+        assert_check_totals(data, atol=1e99, rtol=1e-8)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
OpenMDAO recently changed the way the error dicts returned by `check_totals` get populated, which caused some of our tests to fail. Using OpenMDAO's built-in `assert_check_totals` method seems to fix this.