### PR TITLE
Modify Funtofem Mphys Imports

### DIFF
--- a/examples/aerostructural/crm9/fun3d_meld_tacs/mphys_analysis.py
+++ b/examples/aerostructural/crm9/fun3d_meld_tacs/mphys_analysis.py
@@ -9,7 +9,7 @@ from mphys import Multipoint
 from mphys.scenario_aerostructural import ScenarioAeroStructural
 from sfe.mphys import Fun3dSfeBuilder
 from tacs.mphys import TacsBuilder
-from pyfuntofem import MeldBuilder
+from pyfuntofem.mphys import MeldBuilder
 
 import tacs_setup
 from structural_patches_component import LumpPatches

--- a/examples/aerostructural/crm9/fun3d_meld_tacs/mphys_analysis.py
+++ b/examples/aerostructural/crm9/fun3d_meld_tacs/mphys_analysis.py
@@ -9,7 +9,7 @@ from mphys import Multipoint
 from mphys.scenario_aerostructural import ScenarioAeroStructural
 from sfe.mphys import Fun3dSfeBuilder
 from tacs.mphys import TacsBuilder
-from funtofem.mphys import MeldBuilder
+from pyfuntofem import MeldBuilder
 
 import tacs_setup
 from structural_patches_component import LumpPatches

--- a/examples/aerostructural/mach_tutorial_wing/adflow_meld_tacs/mphys_as_2scenario.py
+++ b/examples/aerostructural/mach_tutorial_wing/adflow_meld_tacs/mphys_as_2scenario.py
@@ -8,7 +8,7 @@ from mphys.scenario_aerostructural import ScenarioAeroStructural
 from adflow.mphys import ADflowBuilder
 from baseclasses import AeroProblem
 from tacs.mphys import TacsBuilder
-from pyfuntofem import MeldBuilder
+from pyfuntofem.mphys import MeldBuilder
 # TODO RLT needs to be updated with the new tacs wrapper
 # from rlt.mphys import RltBuilder
 

--- a/examples/aerostructural/mach_tutorial_wing/adflow_meld_tacs/mphys_as_2scenario.py
+++ b/examples/aerostructural/mach_tutorial_wing/adflow_meld_tacs/mphys_as_2scenario.py
@@ -8,7 +8,7 @@ from mphys.scenario_aerostructural import ScenarioAeroStructural
 from adflow.mphys import ADflowBuilder
 from baseclasses import AeroProblem
 from tacs.mphys import TacsBuilder
-from funtofem.mphys import MeldBuilder
+from pyfuntofem import MeldBuilder
 # TODO RLT needs to be updated with the new tacs wrapper
 # from rlt.mphys import RltBuilder
 

--- a/examples/aerostructural/mach_tutorial_wing/vlm_meld_tacs/as_opt.py
+++ b/examples/aerostructural/mach_tutorial_wing/vlm_meld_tacs/as_opt.py
@@ -5,7 +5,7 @@ from mphys.multipoint import Multipoint
 from mphys.scenario_aerostructural import ScenarioAeroStructural
 from vlm_solver.mphys_vlm import VlmBuilder
 from tacs.mphys import TacsBuilder
-from funtofem.mphys import MeldBuilder
+from pyfuntofem import MeldBuilder
 
 from struct_dv_components import StructDvMapper, SmoothnessEvaluatorGrid, struct_comps
 import tacs_setup

--- a/examples/aerostructural/mach_tutorial_wing/vlm_meld_tacs/as_opt.py
+++ b/examples/aerostructural/mach_tutorial_wing/vlm_meld_tacs/as_opt.py
@@ -5,7 +5,7 @@ from mphys.multipoint import Multipoint
 from mphys.scenario_aerostructural import ScenarioAeroStructural
 from vlm_solver.mphys_vlm import VlmBuilder
 from tacs.mphys import TacsBuilder
-from pyfuntofem import MeldBuilder
+from pyfuntofem.mphys import MeldBuilder
 
 from struct_dv_components import StructDvMapper, SmoothnessEvaluatorGrid, struct_comps
 import tacs_setup

--- a/examples/aerostructural/mach_tutorial_wing/vlm_meld_tacs/run_analysis.py
+++ b/examples/aerostructural/mach_tutorial_wing/vlm_meld_tacs/run_analysis.py
@@ -9,7 +9,7 @@ from mphys import Multipoint
 from mphys.scenario_aerostructural import ScenarioAeroStructural
 from vlm_solver.mphys_vlm import VlmBuilder
 from tacs.mphys import TacsBuilder
-from funtofem.mphys import MeldBuilder
+from pyfuntofem import MeldBuilder
 
 import tacs_setup
 

--- a/examples/aerostructural/mach_tutorial_wing/vlm_meld_tacs/run_analysis.py
+++ b/examples/aerostructural/mach_tutorial_wing/vlm_meld_tacs/run_analysis.py
@@ -9,7 +9,7 @@ from mphys import Multipoint
 from mphys.scenario_aerostructural import ScenarioAeroStructural
 from vlm_solver.mphys_vlm import VlmBuilder
 from tacs.mphys import TacsBuilder
-from pyfuntofem import MeldBuilder
+from pyfuntofem.mphys import MeldBuilder
 
 import tacs_setup
 

--- a/examples/aerostructural/mach_tutorial_wing/vlm_meld_tacs/run_analysis_parallel.py
+++ b/examples/aerostructural/mach_tutorial_wing/vlm_meld_tacs/run_analysis_parallel.py
@@ -9,7 +9,7 @@ from mphys import MultipointParallel
 from mphys.scenario_aerostructural import ScenarioAeroStructural
 from vlm_solver.mphys_vlm import VlmBuilder
 from tacs.mphys import TacsBuilder
-from funtofem.mphys import MeldBuilder
+from pyfuntofem import MeldBuilder
 
 import tacs_setup
 

--- a/examples/aerostructural/mach_tutorial_wing/vlm_meld_tacs/run_analysis_parallel.py
+++ b/examples/aerostructural/mach_tutorial_wing/vlm_meld_tacs/run_analysis_parallel.py
@@ -9,7 +9,7 @@ from mphys import MultipointParallel
 from mphys.scenario_aerostructural import ScenarioAeroStructural
 from vlm_solver.mphys_vlm import VlmBuilder
 from tacs.mphys import TacsBuilder
-from pyfuntofem import MeldBuilder
+from pyfuntofem.mphys import MeldBuilder
 
 import tacs_setup
 

--- a/tests/integration_tests/test_meld_derivs.py
+++ b/tests/integration_tests/test_meld_derivs.py
@@ -19,7 +19,7 @@ import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
 
 from mphys import Builder
-from pyfuntofem import MeldBuilder
+from pyfuntofem.mphys import MeldBuilder
 
 
 isym = 1

--- a/tests/integration_tests/test_meld_derivs.py
+++ b/tests/integration_tests/test_meld_derivs.py
@@ -19,7 +19,7 @@ import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
 
 from mphys import Builder
-from funtofem.mphys import MeldBuilder
+from pyfuntofem import MeldBuilder
 
 
 isym = 1

--- a/tests/integration_tests/test_oas_tacs_meld_partials.py
+++ b/tests/integration_tests/test_oas_tacs_meld_partials.py
@@ -9,7 +9,7 @@ from mphys import Multipoint
 from mphys.scenario_aerostructural import ScenarioAeroStructural
 from openaerostruct.mphys.aero_builder import AeroBuilder
 from tacs.mphys import TacsBuilder
-from funtofem.mphys import MeldBuilder
+from pyfuntofem import MeldBuilder
 
 from tacs import elements, constitutive, functions
 

--- a/tests/integration_tests/test_oas_tacs_meld_partials.py
+++ b/tests/integration_tests/test_oas_tacs_meld_partials.py
@@ -9,7 +9,7 @@ from mphys import Multipoint
 from mphys.scenario_aerostructural import ScenarioAeroStructural
 from openaerostruct.mphys.aero_builder import AeroBuilder
 from tacs.mphys import TacsBuilder
-from pyfuntofem import MeldBuilder
+from pyfuntofem.mphys import MeldBuilder
 
 from tacs import elements, constitutive, functions
 

--- a/tests/integration_tests/test_oas_tacs_meld_totals.py
+++ b/tests/integration_tests/test_oas_tacs_meld_totals.py
@@ -8,7 +8,7 @@ from openmdao.utils.assert_utils import assert_check_totals
 from mphys import Multipoint
 from mphys.scenario_aerostructural import ScenarioAeroStructural
 from openaerostruct.mphys import AeroBuilder
-from pyfuntofem import MeldBuilder
+from pyfuntofem.mphys import MeldBuilder
 
 from tacs import elements, constitutive, functions
 from tacs.mphys import TacsBuilder

--- a/tests/integration_tests/test_oas_tacs_meld_totals.py
+++ b/tests/integration_tests/test_oas_tacs_meld_totals.py
@@ -8,7 +8,7 @@ from openmdao.utils.assert_utils import assert_check_totals
 from mphys import Multipoint
 from mphys.scenario_aerostructural import ScenarioAeroStructural
 from openaerostruct.mphys import AeroBuilder
-from funtofem.mphys import MeldBuilder
+from pyfuntofem import MeldBuilder
 
 from tacs import elements, constitutive, functions
 from tacs.mphys import TacsBuilder

--- a/tests/integration_tests/vlm_tacs_meld_check_partials.py
+++ b/tests/integration_tests/vlm_tacs_meld_check_partials.py
@@ -7,7 +7,7 @@ from mphys import Multipoint
 from mphys.scenario_aerostructural import ScenarioAeroStructural
 from vlm_solver.mphys_vlm import VlmBuilder
 from tacs.mphys import TacsBuilder
-from funtofem.mphys import MeldBuilder
+from pyfuntofem import MeldBuilder
 
 from tacs import elements, constitutive, functions
 

--- a/tests/integration_tests/vlm_tacs_meld_check_partials.py
+++ b/tests/integration_tests/vlm_tacs_meld_check_partials.py
@@ -7,7 +7,7 @@ from mphys import Multipoint
 from mphys.scenario_aerostructural import ScenarioAeroStructural
 from vlm_solver.mphys_vlm import VlmBuilder
 from tacs.mphys import TacsBuilder
-from pyfuntofem import MeldBuilder
+from pyfuntofem.mphys import MeldBuilder
 
 from tacs import elements, constitutive, functions
 

--- a/tests/integration_tests/vlm_tacs_meld_check_totals.py
+++ b/tests/integration_tests/vlm_tacs_meld_check_totals.py
@@ -8,7 +8,7 @@ from mphys import Multipoint
 from mphys.scenario_aerostructural import ScenarioAeroStructural
 from vlm_solver.mphys_vlm import VlmBuilder
 from tacs.mphys import TacsBuilder
-from pyfuntofem import MeldBuilder
+from pyfuntofem.mphys import MeldBuilder
 
 from tacs import elements, constitutive, functions
 

--- a/tests/integration_tests/vlm_tacs_meld_check_totals.py
+++ b/tests/integration_tests/vlm_tacs_meld_check_totals.py
@@ -8,7 +8,7 @@ from mphys import Multipoint
 from mphys.scenario_aerostructural import ScenarioAeroStructural
 from vlm_solver.mphys_vlm import VlmBuilder
 from tacs.mphys import TacsBuilder
-from funtofem.mphys import MeldBuilder
+from pyfuntofem import MeldBuilder
 
 from tacs import elements, constitutive, functions
 

--- a/tests/regression_tests/test_aerostruct.py
+++ b/tests/regression_tests/test_aerostruct.py
@@ -30,7 +30,7 @@ from mphys.scenario_aerostructural import ScenarioAeroStructural
 # these imports will be from the respective codes' repos rather than mphys
 from adflow.mphys import ADflowBuilder
 from tacs.mphys import TacsBuilder
-from pyfuntofem import MeldBuilder
+from pyfuntofem.mphys import MeldBuilder
 # TODO RLT needs to be updated with the new tacs wrapper
 # from rlt.mphys import RltBuilder
 

--- a/tests/regression_tests/test_aerostruct.py
+++ b/tests/regression_tests/test_aerostruct.py
@@ -30,7 +30,7 @@ from mphys.scenario_aerostructural import ScenarioAeroStructural
 # these imports will be from the respective codes' repos rather than mphys
 from adflow.mphys import ADflowBuilder
 from tacs.mphys import TacsBuilder
-from funtofem.mphys import MeldBuilder
+from pyfuntofem import MeldBuilder
 # TODO RLT needs to be updated with the new tacs wrapper
 # from rlt.mphys import RltBuilder
 

--- a/tests/regression_tests/test_dafoam_aerostruct.py
+++ b/tests/regression_tests/test_dafoam_aerostruct.py
@@ -26,7 +26,7 @@ from mphys.scenario_aerostructural import ScenarioAeroStructural
 # these imports will be from the respective codes' repos rather than mphys
 from dafoam.mphys import DAFoamBuilder
 from tacs.mphys import TacsBuilder
-from pyfuntofem import MeldBuilder
+from pyfuntofem.mphys import MeldBuilder
 from pygeo.mphys import OM_DVGEOCOMP
 
 from tacs import elements, constitutive, functions

--- a/tests/regression_tests/test_dafoam_aerostruct.py
+++ b/tests/regression_tests/test_dafoam_aerostruct.py
@@ -26,7 +26,7 @@ from mphys.scenario_aerostructural import ScenarioAeroStructural
 # these imports will be from the respective codes' repos rather than mphys
 from dafoam.mphys import DAFoamBuilder
 from tacs.mphys import TacsBuilder
-from funtofem.mphys import MeldBuilder
+from pyfuntofem import MeldBuilder
 from pygeo.mphys import OM_DVGEOCOMP
 
 from tacs import elements, constitutive, functions


### PR DESCRIPTION
* We are cleaning up funtofem Cython and python files, including moving the `funtofem/mphys` folder into the `pyfuntofem` folder, see the PR https://github.com/smdogroup/funtofem/pull/183.
* The import of the `MeldBuilder` class would be changed from `from funtofem.mphys import MeldBuilder` to `from pyfuntofem import MeldBuilder`. Another option to import after this change would be `from pyfuntofem.interface.mphys import MeldBuilder`.