### PR TITLE
Adding SkipUnless check for complex tests being run w/ real tacs/meld

### DIFF
--- a/tests/integration_tests/test_meld_derivs.py
+++ b/tests/integration_tests/test_meld_derivs.py
@@ -19,6 +19,7 @@ import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
 
 from mphys import Builder
+from funtofem import TransferScheme
 from funtofem.mphys import MeldBuilder
 
 
@@ -118,6 +119,8 @@ class TestXferClasses(unittest.TestCase):
     def test_run_model(self):
         self.prob.run_model()
 
+    @unittest.skipUnless(TransferScheme.dtype == complex,
+                         "FunToFem must be compiled in complex mode.")
     def test_derivatives(self):
         self.prob.run_model()
         data = self.prob.check_partials(compact_print=True, method='cs')

--- a/tests/integration_tests/test_oas_tacs_meld_partials.py
+++ b/tests/integration_tests/test_oas_tacs_meld_partials.py
@@ -9,9 +9,10 @@ from mphys import Multipoint
 from mphys.scenario_aerostructural import ScenarioAeroStructural
 from openaerostruct.mphys.aero_builder import AeroBuilder
 from tacs.mphys import TacsBuilder
+from funtofem import TransferScheme
 from funtofem.mphys import MeldBuilder
 
-from tacs import elements, constitutive, functions
+from tacs import elements, constitutive, functions, TACS
 
 # Callback function used to setup TACS element objects and DVs
 def element_callback(dvNum, compID, compDescript, elemDescripts, specialDVs, **kwargs):
@@ -161,6 +162,8 @@ class TestOAS(unittest.TestCase):
     def test_run_model(self):
         self.prob.run_model()
 
+    @unittest.skipUnless(TACS.dtype == complex and TransferScheme.dtype == complex,
+                         "TACS/FunToFem must be compiled in complex mode.")
     def test_derivatives(self):
         self.prob.run_model()
         print('----------------starting check totals--------------')

--- a/tests/integration_tests/test_tacs_derivs.py
+++ b/tests/integration_tests/test_tacs_derivs.py
@@ -19,7 +19,7 @@ from openmdao.utils.assert_utils import assert_check_totals
 from mphys.multipoint import Multipoint
 from mphys.scenario_structural import ScenarioStructural
 
-from tacs import elements, constitutive, functions
+from tacs import elements, constitutive, functions, TACS
 from tacs.mphys import TacsBuilder
 
 baseDir = os.path.dirname(os.path.abspath(__file__))
@@ -101,6 +101,7 @@ class TestTACS(unittest.TestCase):
     def test_run_model(self):
         self.prob.run_model()
 
+    @unittest.skipUnless(TACS.dtype == complex, "TACS must be compiled in complex mode.")
     def test_derivatives(self):
         self.prob.run_model()
         print('----------------starting check totals--------------')

--- a/tests/integration_tests/test_tacs_partials.py
+++ b/tests/integration_tests/test_tacs_partials.py
@@ -8,7 +8,7 @@ from openmdao.utils.assert_utils import assert_near_equal
 from mphys.multipoint import Multipoint
 from mphys.scenario_structural import ScenarioStructural
 
-from tacs import elements, constitutive, functions
+from tacs import elements, constitutive, functions, TACS
 from tacs.mphys import TacsBuilder
 
 # Callback function used to setup TACS element objects and DVs
@@ -80,6 +80,7 @@ class TestTACS(unittest.TestCase):
     def test_run_model(self):
         self.prob.run_model()
 
+    @unittest.skipUnless(TACS.dtype == complex, "TACS must be compiled in complex mode.")
     def test_derivatives(self):
         self.prob.run_model()
         print('----------------starting check totals--------------')


### PR DESCRIPTION
Adding explicit skip check and message for case where integration tests are being run w/ real-mode TACS/MELD.

Should make Issue #150 clearer for new users