### PR TITLE
fixed embed-options in documentation

### DIFF
--- a/docs/_exts/embed_options.py
+++ b/docs/_exts/embed_options.py
@@ -44,7 +44,7 @@ class EmbedOptionsDirective(Directive):
         lines = ViewList()
 
         n = 0
-        for line in options.__rst__():
+        for line in options.__rst__().split('\n'):
             lines.append(line, "options table", n)
             n += 1
 

--- a/docs/scenarios/aerodynamic.rst
+++ b/docs/scenarios/aerodynamic.rst
@@ -7,8 +7,8 @@ Default Solvers
 ===============
 The default solvers are NonlinearRunOnce and LinearRunOnce that execute the pre coupling, coupling, and post coupling subsystems in order.
 
-StructuralScenario Options
-==========================
+Options
+=======
 .. embed-options::
   mphys.scenario_aerodynamic
   ScenarioAerodynamic


### PR DESCRIPTION
Previously, when using embed-options in sphinx documentation, docs/_exts/embed_options.py was adding each character of  OptionsDictionary.__rst__() as its own line. This was fixed by splitting __rst__() by newline.