### PR TITLE
Fixing CI

### DIFF
--- a/.github/workflows/unit_tests_and_docs.yml
+++ b/.github/workflows/unit_tests_and_docs.yml
@@ -39,8 +39,7 @@ jobs:
           echo "=============================================================";
           source $CONDA/etc/profile.d/conda.sh;
           echo $CONDA/bin >> $GITHUB_PATH;
-          conda create -n OpenMDAO python=3.8 numpy=1 scipy=1 -q -y;
-          conda install -c conda-forge mamba=1.5.1 -q -y;
+          conda create -n OpenMDAO -c conda-forge python=3.8 mamba=1.5.1 -q -y;
           conda activate OpenMDAO;
           pip install --upgrade pip
           echo "=============================================================";

--- a/.github/workflows/unit_tests_and_docs.yml
+++ b/.github/workflows/unit_tests_and_docs.yml
@@ -40,7 +40,7 @@ jobs:
           source $CONDA/etc/profile.d/conda.sh;
           echo $CONDA/bin >> $GITHUB_PATH;
           conda create -n OpenMDAO python=3.8 numpy=1 scipy=1 -q -y;
-          conda install -c conda-forge mamba -q -y;
+          conda install -c conda-forge mamba=1.5.1 -q -y;
           conda activate OpenMDAO;
           pip install --upgrade pip
           echo "=============================================================";

--- a/.github/workflows/unit_tests_and_docs.yml
+++ b/.github/workflows/unit_tests_and_docs.yml
@@ -40,12 +40,13 @@ jobs:
           source $CONDA/etc/profile.d/conda.sh;
           echo $CONDA/bin >> $GITHUB_PATH;
           conda create -n OpenMDAO python=3.8 numpy=1 scipy=1 -q -y;
+          conda install -c conda-forge mamba -q -y;
           conda activate OpenMDAO;
           pip install --upgrade pip
           echo "=============================================================";
           echo "Install PETSc";
           echo "=============================================================";
-          conda install -c conda-forge mpi4py petsc4py -q -y;
+          mamba install -c conda-forge mpi4py=3.1.4 petsc4py -q -y;
           echo "=============================================================";
           echo "Install OpenMDAO";
           echo "=============================================================";
@@ -60,7 +61,6 @@ jobs:
           echo "=============================================================";
           echo "Install optional dependencies";
           echo "=============================================================";
-          conda install -c conda-forge mamba -q -y;
           mamba install -c "smdogroup/label/complex" -c smdogroup -c conda-forge tacs funtofem -q -y;
           pip install openaerostruct;
           echo "=============================================================";


### PR DESCRIPTION
a new [version](https://anaconda.org/conda-forge/mpi4py) of mpi4py (3.1.5) was released on conda-forge yesterday. This version is breaking our CI tests for some reason (see [here](https://github.com/OpenMDAO/mphys/actions/runs/6548324776/job/17783072987#step:4:1481) and [here](https://github.com/conda-forge/mpi4py-feedstock/pull/65#issuecomment-1766236104)). For now, pinning against the older 3.1.4 fixes the issue. 