### PR TITLE
Bumping CI Python to 3.9

### DIFF
--- a/.github/workflows/unit_tests_and_docs.yml
+++ b/.github/workflows/unit_tests_and_docs.yml
@@ -39,7 +39,7 @@ jobs:
           echo "=============================================================";
           source $CONDA/etc/profile.d/conda.sh;
           echo $CONDA/bin >> $GITHUB_PATH;
-          conda create -n OpenMDAO -c conda-forge python=3.8 mamba=1.5.1 -q -y;
+          conda create -n OpenMDAO -c conda-forge python=3.9 mamba=1.5.1 -q -y;
           conda activate OpenMDAO;
           pip install --upgrade pip
           echo "=============================================================";


### PR DESCRIPTION
In preparation for 3.8's EOL later this year and continue using tacs' latest version