### PR TITLE
Make setup() in scenario switch directory if set

### DIFF
--- a/mphys/core/scenario.py
+++ b/mphys/core/scenario.py
@@ -41,6 +41,7 @@ class Scenario(MPhysGroup):
         """
         pass
 
+    @switch_run_directory
     def setup(self):
         """
         The main setup call for all multiphysics scenarios.


### PR DESCRIPTION
When running a multipoint case, the MPhys scenario class has a `run_directory` option to run each scenario in a particular directory. The purpose of this is that if a solver writes **output** files like residual histories, visualization files, restart files, etc. then scenarios will not overwrite each other's files. 

Another potential use of switching directories is specifying separate **input** options for separate scenarios. For example, 
Having `scenario0/driver.cfg` and `scenario1/driver.cfg`. A typical way this would be implemented is the Builder reading these inputs during `initialize()`. For a serial Multipoint case, the user would handle reading the inputs separately or switching directories before calling initialize. However in parallel Multipoint cases where `initialize()` is called within the scenario, the builder currently has no way to know which input file to use.

The change makes a scenario switch directories in `setup()`, which means that calls to Builders' `initialize()` will be done while in the scenario directory. 