### PR TITLE
Adding OAS tests back to CI

### DIFF
--- a/.github/workflows/unit_tests_and_docs.yml
+++ b/.github/workflows/unit_tests_and_docs.yml
@@ -79,7 +79,7 @@ jobs:
           chmod +x get-input-files.sh
           ./get-input-files.sh
           cd ../integration_tests
-          testflo test_tacs_* test_meld_* #test_oas_*
+          testflo test_tacs_* test_meld_* test_oas_*
           echo "=============================================================";
           echo "Making docs";
           echo "=============================================================";

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Open-source codes with builders and components compatible with mphys:
 |------------------------------------------------------------|----------------------|--------------------------------|-------------------------------------------------------------------------|
 | [ADflow](https://github.com/mdolab/adflow)                 | 2.12.0               | Aerodynamics                   | Structured multi-block and overset CFD.                                 |
 | [DAfoam](https://github.com/mdolab/dafoam)                 | 3.2.0                | Aerodynamics                   | Discrete Adjoint with OpenFOAM.                                         |
-| [OpenAeroStruct](https://github.com/mdolab/openaerostruct) | 2.10.0               | Aerodynamics                   | Vortex lattice aerodynamics written using OpenMDAO.                     |
+| [OpenAeroStruct](https://github.com/mdolab/openaerostruct) | 2.9.1                | Aerodynamics                   | Vortex lattice aerodynamics written using OpenMDAO.                     |
 | [FunToFEM](https://github.com/smdogroup/funtofem)          | 0.3.8                | Load and Displacement Transfer | Point cloud based transfer scheme. Part of the FUNtoFEM package.        |
 | [pyCycle](https://github.com/OpenMDAO/pyCycle)             | 4.3.0                | Propulsion                     | Thermodynamic cycle modeling library for engines.                       |
 | [pyGeo](https://github.com/mdolab/pygeo)                   | 1.15.0               | Geometric Parameterization     | Wrapper for ESP, OpenVSP, and a free-form deformation parameterization. |


### PR DESCRIPTION
OpenAeroStruct 2.9.1 has been [released](https://github.com/mdolab/OpenAeroStruct/releases/tag/v2.9.1) which includes new MPhys interface. Turning OAS tests back on in CI. 

Closes #188 