### PR TITLE
Adding Coupling Loads to TACS Setup in `adflow_meld_mphys` Example

### DIFF
--- a/examples/aerostructural/mach_tutorial_wing/adflow_meld_tacs/mphys_as_2scenario.py
+++ b/examples/aerostructural/mach_tutorial_wing/adflow_meld_tacs/mphys_as_2scenario.py
@@ -77,6 +77,7 @@ class Top(Multipoint):
         struct_builder = TacsBuilder(
             mesh_file="wingbox.bdf",
             element_callback=tacs_setup.element_callback,
+            coupling_loads=[MPhysVariables.Structures.Loads.AERODYNAMIC],
             problem_setup=tacs_setup.problem_setup,
         )
         struct_builder.initialize(self.comm)


### PR DESCRIPTION
Modified `examples/aerostructural/mach_tutorial_wing/adflow_meld_tacs/mphys_as_2scenario.py`. to include coupling loads in the TACS setup. This addition is necessary for proper coupling in the aerostructural analysis.