### PR TITLE
Updated `configure()` in `Top` Class to add the linear and nonlinear solvers

### DIFF
--- a/examples/aerostructural/mach_tutorial_wing/adflow_meld_tacs/mphys_as_2scenario.py
+++ b/examples/aerostructural/mach_tutorial_wing/adflow_meld_tacs/mphys_as_2scenario.py
@@ -140,6 +140,7 @@ class Top(Multipoint):
             self.connect("dv_struct", f"{scenario}.dv_struct")
 
     def configure(self):
+        super().configure() # adds linear and nonlinear solvers defined in setup
         # create the aero problems for both analysis point.
         # this is custom to the ADflow based approach we chose here.
         # any solver can have their own custom approach here, and we don't

--- a/examples/aerostructural/mach_tutorial_wing/adflow_meld_tacs/mphys_as_2scenario.py
+++ b/examples/aerostructural/mach_tutorial_wing/adflow_meld_tacs/mphys_as_2scenario.py
@@ -140,7 +140,7 @@ class Top(Multipoint):
             self.connect("dv_struct", f"{scenario}.dv_struct")
 
     def configure(self):
-        super().configure() # adds linear and nonlinear solvers defined in setup
+        super().configure()  # adds linear and nonlinear solvers defined in setup
         # create the aero problems for both analysis point.
         # this is custom to the ADflow based approach we chose here.
         # any solver can have their own custom approach here, and we don't


### PR DESCRIPTION
Modified the `configure()` method in `Top` class, in `examples/aerostructural/mach_tutorial_wing/adflow_meld_tacs/mphys_as_2scenario.py` to call the parent class's `configure()` method. This addition is necessary for adding the solvers defined in setup instead of using the default ones.