### PR TITLE
Added a workflow to publish to PyPi when a release is made on GitHub

### DIFF
--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -1,0 +1,38 @@
+# Publish release to PyPi
+
+name: Publish Release
+
+on:
+  # Trigger on release, to publish release packages to PyPI
+  release:
+    types: [published]
+
+  # Run the workflow manually
+  # This might be useful if the automated publish fails for some reason (use with CARE!!)
+  workflow_dispatch:
+
+jobs:
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+
+    environment: release
+
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+
+      - name: deps
+        run: python -m pip install -U hatch
+
+      - name: build
+        run: hatch build
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,6 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = ["setuptools"]
+
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Added a workflow to publish to `PyPi` when a release is made on `GitHub`

Also added the build dependencies to `pyproject.toml` to facilitate building the package for `PyPi`