### PR TITLE
remove max width from sphinxdoc theme

### DIFF
--- a/.github/workflows/host_docs.yml
+++ b/.github/workflows/host_docs.yml
@@ -37,7 +37,7 @@ jobs:
           conda create -n OpenMDAO -c conda-forge python=3.12 mamba=2.0.5 -q -y;
           conda activate OpenMDAO;
           pip install --upgrade pip
-          conda install -c conda-forge numpy=2.0 scipy=1.15 lapack -q -y;
+          conda install -c conda-forge numpy=1.26 scipy=1.15 lapack -q -y;
           echo "=============================================================";
           echo "Install PETSc";
           echo "=============================================================";


### PR DESCRIPTION
Documentation tables such as the naming convention one: https://openmdao.github.io/mphys/basics/naming_conventions.html have maximum widths that can make them hard to read. This is one fix that removes the max body width from the sphinx theme. Open to any suggestions if anyone doesn't like how this looks...