### PR TITLE
make remote server handle array constraint bounds

### DIFF
--- a/mphys/network/remote_component.py
+++ b/mphys/network/remote_component.py
@@ -484,9 +484,10 @@ class RemoteComp(om.ExplicitComponent):
                         ),
                     )
                 else:
-                    if (
-                        self._lower_bound_used(output_dict["constraints"][con]["lower"])
-                        and self._upper_bound_used(output_dict["constraints"][con]["upper"])
+                    if self._lower_bound_used(
+                        output_dict["constraints"][con]["lower"]
+                    ) and self._upper_bound_used(
+                        output_dict["constraints"][con]["upper"]
                     ):  # enforce lower and upper bounds
                         self.add_constraint(
                             con.replace(".", self.var_naming_dot_replacement),
@@ -503,8 +504,8 @@ class RemoteComp(om.ExplicitComponent):
                                 else None
                             ),
                         )
-                    elif (
-                        self._lower_bound_used(output_dict["constraints"][con]["lower"])
+                    elif self._lower_bound_used(
+                        output_dict["constraints"][con]["lower"]
                     ):  # enforce lower bound
                         self.add_constraint(
                             con.replace(".", self.var_naming_dot_replacement),

--- a/mphys/network/remote_component.py
+++ b/mphys/network/remote_component.py
@@ -446,6 +446,18 @@ class RemoteComp(om.ExplicitComponent):
                 )
                 self.derivative_coloring_num += 1
 
+    def _lower_bound_used(self, bound):
+        if hasattr(bound, "__len__"):
+            return (np.array(bound) > -1e20).any()
+        else:
+            return bound
+
+    def _upper_bound_used(self, bound):
+        if hasattr(bound, "__len__"):
+            return (np.array(bound) < 1e20).any()
+        else:
+            return bound
+
     def _add_constraints_from_baseline_model(self, output_dict):
         for con in output_dict["constraints"].keys():
             self.add_output(
@@ -473,8 +485,8 @@ class RemoteComp(om.ExplicitComponent):
                     )
                 else:
                     if (
-                        output_dict["constraints"][con]["lower"] > -1e20
-                        and output_dict["constraints"][con]["upper"] < 1e20
+                        self._lower_bound_used(output_dict["constraints"][con]["lower"])
+                        and self._upper_bound_used(output_dict["constraints"][con]["upper"])
                     ):  # enforce lower and upper bounds
                         self.add_constraint(
                             con.replace(".", self.var_naming_dot_replacement),
@@ -492,7 +504,7 @@ class RemoteComp(om.ExplicitComponent):
                             ),
                         )
                     elif (
-                        output_dict["constraints"][con]["lower"] > -1e20
+                        self._lower_bound_used(output_dict["constraints"][con]["lower"])
                     ):  # enforce lower bound
                         self.add_constraint(
                             con.replace(".", self.var_naming_dot_replacement),

--- a/mphys/network/server.py
+++ b/mphys/network/server.py
@@ -276,6 +276,18 @@ class Server:
             )
         return desvar_dict
 
+    def _lower_bound_used(self, bound):
+        if hasattr(bound, "__len__"):
+            return (bound > -1e20).any()
+        else:
+            return bound
+
+    def _upper_bound_used(self, bound):
+        if hasattr(bound, "__len__"):
+            return (bound < 1e20).any()
+        else:
+            return bound
+
     def _apply_reference_vals_to_constraint_bounds(self, constraint_dict):
         if (
             constraint_dict["adder"] is None and constraint_dict["scaler"] is None
@@ -287,13 +299,13 @@ class Server:
                     + constraint_dict["ref0"]
                 )
             else:
-                if constraint_dict["lower"] > -1e20:
+                if self._lower_bound_used(constraint_dict["lower"]):
                     constraint_dict["lower"] = (
                         constraint_dict["lower"]
                         * (constraint_dict["ref"] - constraint_dict["ref0"])
                         + constraint_dict["ref0"]
                     )
-                if constraint_dict["upper"] < 1e20:
+                if self._upper_bound_used(constraint_dict["upper"]):
                     constraint_dict["upper"] = (
                         constraint_dict["upper"]
                         * (constraint_dict["ref"] - constraint_dict["ref0"])
@@ -306,12 +318,12 @@ class Server:
                     - constraint_dict["adder"]
                 )
             else:
-                if constraint_dict["lower"] > -1e20:
+                if self._lower_bound_used(constraint_dict["lower"]):
                     constraint_dict["lower"] = (
                         constraint_dict["lower"] / constraint_dict["scaler"]
                         - constraint_dict["adder"]
                     )
-                if constraint_dict["upper"] < 1e20:
+                if self._upper_bound_used(constraint_dict["upper"]):
                     constraint_dict["upper"] = (
                         constraint_dict["upper"] / constraint_dict["scaler"]
                         - constraint_dict["adder"]


### PR DESCRIPTION
Previously, constraint handling performed on the server side would fail if lower/upper bounds were array types. This PR adds a couple functions, _lower_bound_used and _upper_bound_used, to handle both scalar and array bounds.