### PR TITLE
fix bug that caused LB/UB to not be enforced by remote component if limit was (scalar) 0

### DIFF
--- a/examples/aerostructural/supersonic_panel/as_opt_remote_parallel.py
+++ b/examples/aerostructural/supersonic_panel/as_opt_remote_parallel.py
@@ -15,9 +15,7 @@ class ParallelRemoteGroup(om.ParallelGroup):
         for i in range(self.options["num_scenarios"]):
 
             pbs_launcher = PBS.k4(
-                profile_filename='~/.bashrc',
-                requested_number_of_nodes=1,
-                time=1
+                profile_filename="~/.bashrc", requested_number_of_nodes=1, time=1
             )
             pbs_launcher.mpiexec = "mpirun"
             pbs_launcher.requested_number_of_nodes = 1

--- a/examples/aerostructural/supersonic_panel/as_opt_remote_parallel.py
+++ b/examples/aerostructural/supersonic_panel/as_opt_remote_parallel.py
@@ -14,7 +14,11 @@ class ParallelRemoteGroup(om.ParallelGroup):
         # NOTE: make sure setup isn't called multiple times, otherwise the first jobs/port forwarding will go unused and you'll have to stop them manually
         for i in range(self.options["num_scenarios"]):
 
-            pbs_launcher = PBS.k4(time=1)
+            pbs_launcher = PBS.k4(
+                profile_filename='~/.bashrc',
+                requested_number_of_nodes=1,
+                time=1
+            )
             pbs_launcher.mpiexec = "mpirun"
             pbs_launcher.requested_number_of_nodes = 1
 

--- a/examples/aerostructural/supersonic_panel/as_opt_remote_serial.py
+++ b/examples/aerostructural/supersonic_panel/as_opt_remote_serial.py
@@ -60,10 +60,25 @@ def run_optimization(prob: om.Problem):
 
 def main():
     check_totals = False
+    hpc = "k" # nas or k
 
-    pbs = PBS.k4(time=1)
-    pbs.mpiexec = "mpirun"
-    pbs.requested_number_of_nodes = 1
+    if hpc == "nas":
+
+        pbs = PBS.nas(
+            profile_filename='~/.bashrc',
+            #group_list=None, # add group list here
+            proc_type='rom',
+            requested_number_of_nodes=1,
+            time=1,
+        )
+
+    elif hpc == "k":
+
+        pbs = PBS.k4(
+            profile_filename='~/.bashrc',
+            requested_number_of_nodes=1,
+            time=1,
+        )
 
     prob = om.Problem()
     prob.model.add_subsystem(

--- a/examples/aerostructural/supersonic_panel/as_opt_remote_serial.py
+++ b/examples/aerostructural/supersonic_panel/as_opt_remote_serial.py
@@ -60,14 +60,14 @@ def run_optimization(prob: om.Problem):
 
 def main():
     check_totals = False
-    hpc = "k" # nas or k
+    hpc = "k"  # nas or k
 
     if hpc == "nas":
 
         pbs = PBS.nas(
-            profile_filename='~/.bashrc',
-            #group_list=None, # add group list here
-            proc_type='rom',
+            profile_filename="~/.bashrc",
+            # group_list=None, # add group list here
+            proc_type="rom",
             requested_number_of_nodes=1,
             time=1,
         )
@@ -75,7 +75,7 @@ def main():
     elif hpc == "k":
 
         pbs = PBS.k4(
-            profile_filename='~/.bashrc',
+            profile_filename="~/.bashrc",
             requested_number_of_nodes=1,
             time=1,
         )

--- a/mphys/network/remote_component.py
+++ b/mphys/network/remote_component.py
@@ -450,13 +450,13 @@ class RemoteComp(om.ExplicitComponent):
         if hasattr(bound, "__len__"):
             return (np.array(bound) > -1e20).any()
         else:
-            return bound
+            return bound > -1e20
 
     def _upper_bound_used(self, bound):
         if hasattr(bound, "__len__"):
             return (np.array(bound) < 1e20).any()
         else:
-            return bound
+            return bound < 1e20
 
     def _add_constraints_from_baseline_model(self, output_dict):
         for con in output_dict["constraints"].keys():

--- a/mphys/network/remote_component.py
+++ b/mphys/network/remote_component.py
@@ -125,6 +125,7 @@ class RemoteComp(om.ExplicitComponent):
         self.var_naming_dot_replacement = self.options["var_naming_dot_replacement"]
         self.use_derivative_coloring = self.options["use_derivative_coloring"]
         self.derivative_coloring_num = 0
+        self.stop_server_for_down_time = self.options["stop_server_for_down_time"]
 
         output_dict = None
         if self.comm.rank == 0:
@@ -171,7 +172,6 @@ class RemoteComp(om.ExplicitComponent):
         self.skip_objective_constraint_definition = self.options[
             "skip_objective_constraint_definition"
         ]
-        self.stop_server_for_down_time = self.options["stop_server_for_down_time"]
 
         self._add_design_inputs_from_baseline_model(output_dict)
         self._add_objectives_from_baseline_model(output_dict)

--- a/mphys/network/remote_component.py
+++ b/mphys/network/remote_component.py
@@ -171,9 +171,7 @@ class RemoteComp(om.ExplicitComponent):
         self.skip_objective_constraint_definition = self.options[
             "skip_objective_constraint_definition"
         ]
-        self.stop_server_for_down_time = self.options[
-            "stop_server_for_down_time"
-        ]
+        self.stop_server_for_down_time = self.options["stop_server_for_down_time"]
 
         self._add_design_inputs_from_baseline_model(output_dict)
         self._add_objectives_from_baseline_model(output_dict)
@@ -243,9 +241,14 @@ class RemoteComp(om.ExplicitComponent):
             self.times_function = np.hstack([self.times_function, model_time_elapsed])
 
         if command != "initialize" and self.stop_server_for_down_time > 0:
-            if self.stop_server_for_down_time == 1 or (self.stop_server_for_down_time == 2 and self._doing_derivative_evaluation(command)):
+            if self.stop_server_for_down_time == 1 or (
+                self.stop_server_for_down_time == 2
+                and self._doing_derivative_evaluation(command)
+            ):
                 if self.comm.rank == 0:
-                    print(f"CLIENT (subsystem {self.name}): Stopping server's HPC job for down time")
+                    print(
+                        f"CLIENT (subsystem {self.name}): Stopping server's HPC job for down time"
+                    )
                 self.server_manager.stop_server()
 
         return remote_output_dict

--- a/mphys/network/remote_component.py
+++ b/mphys/network/remote_component.py
@@ -112,6 +112,13 @@ class RemoteComp(om.ExplicitComponent):
             types=bool,
             desc="Skip the objective/constraint definition. The quantities will still be added to outputs",
         )
+        self.options.declare(
+            "stop_server_for_down_time",
+            default=0,
+            types=int,
+            desc="Stop server after evaluation, in case significant down time is expected afterwards. Allows user to conserve HPC "
+            + "SBUs in certain applications. 0=never, 1=after first function call, 2=after first derivative call.",
+        )
 
     @switch_run_directory
     def setup(self):
@@ -163,6 +170,9 @@ class RemoteComp(om.ExplicitComponent):
         self.output_dict = output_dict  # save to access design info
         self.skip_objective_constraint_definition = self.options[
             "skip_objective_constraint_definition"
+        ]
+        self.stop_server_for_down_time = self.options[
+            "stop_server_for_down_time"
         ]
 
         self._add_design_inputs_from_baseline_model(output_dict)
@@ -231,6 +241,12 @@ class RemoteComp(om.ExplicitComponent):
             self.times_gradient = np.hstack([self.times_gradient, model_time_elapsed])
         else:
             self.times_function = np.hstack([self.times_function, model_time_elapsed])
+
+        if command != "initialize" and self.stop_server_for_down_time > 0:
+            if self.stop_server_for_down_time == 1 or (self.stop_server_for_down_time == 2 and self._doing_derivative_evaluation(command)):
+                if self.comm.rank == 0:
+                    print(f"CLIENT (subsystem {self.name}): Stopping server's HPC job for down time")
+                self.server_manager.stop_server()
 
         return remote_output_dict
 

--- a/mphys/network/remote_component.py
+++ b/mphys/network/remote_component.py
@@ -240,7 +240,7 @@ class RemoteComp(om.ExplicitComponent):
         else:
             self.times_function = np.hstack([self.times_function, model_time_elapsed])
 
-        if command != "initialize" and self.stop_server_for_down_time > 0:
+        if self.stop_server_for_down_time > 0:
             if self.stop_server_for_down_time == 1 or (
                 self.stop_server_for_down_time == 2
                 and self._doing_derivative_evaluation(command)

--- a/mphys/network/zmq_pbs.py
+++ b/mphys/network/zmq_pbs.py
@@ -123,16 +123,19 @@ class MPhysZeroMQServerManager(ServerManager):
         self._initialize_connection()
         self.server_counter += 1
         self._launch_job()
+        self.server_stopped = False
 
     def stop_server(self):
-        print(
-            f"CLIENT (subsystem {self.component_name}): Stopping the remote analysis server",
-            flush=True,
-        )
-        if self.job.state == "R":
-            self.socket.send("shutdown|null".encode())
-        self._shutdown_server()
-        self.socket.close()
+        if not self.server_stopped:
+            print(
+                f"CLIENT (subsystem {self.component_name}): Stopping the remote analysis server",
+                flush=True,
+            )
+            if self.job.state == "R":
+                self.socket.send("shutdown|null".encode())
+            self._shutdown_server()
+            self.socket.close()
+            self.server_stopped = True
 
     def enough_time_is_remaining(self, estimated_model_time):
         self.job.update_job_state()
@@ -143,7 +146,7 @@ class MPhysZeroMQServerManager(ServerManager):
 
     def job_has_expired(self):
         self.job.update_job_state()
-        if self.job.state == "R":
+        if self.job.state == "R" and not self.server_stopped:
             return False
         else:
             if self.job_expiration_max_restarts is not None:


### PR DESCRIPTION
The recent functions _lower_bound_used and _upper_bound_used on the client side mistakenly returned bound instead of bound>-1e20 or bound<1e20, if the lower/upper bound returned from the server side was a scalar. I think that caused any constraints of limits of a scalar zero to not be enforced on the client side.